### PR TITLE
Feature implementation from commits a744a20..79bbd89

### DIFF
--- a/ee/packages/git-sync-manager/src/models.ts
+++ b/ee/packages/git-sync-manager/src/models.ts
@@ -244,7 +244,9 @@ export type BlueprintRelation = {
   allowMultiple: Scalars['Boolean']['output'];
   description?: Maybe<Scalars['String']['output']>;
   key: Scalars['String']['output'];
+  limitSelectionToProject: Scalars['Boolean']['output'];
   name: Scalars['String']['output'];
+  parentShouldBuildWithChild: Scalars['Boolean']['output'];
   relatedTo: Scalars['String']['output'];
   required: Scalars['Boolean']['output'];
 };
@@ -253,7 +255,9 @@ export type BlueprintRelationUpsertInput = {
   allowMultiple: Scalars['Boolean']['input'];
   description?: InputMaybe<Scalars['String']['input']>;
   key: Scalars['String']['input'];
+  limitSelectionToProject: Scalars['Boolean']['input'];
   name: Scalars['String']['input'];
+  parentShouldBuildWithChild: Scalars['Boolean']['input'];
   relatedTo: Scalars['String']['input'];
   required: Scalars['Boolean']['input'];
 };

--- a/libs/util/code-gen-types/src/models.ts
+++ b/libs/util/code-gen-types/src/models.ts
@@ -244,7 +244,9 @@ export type BlueprintRelation = {
   allowMultiple: Scalars['Boolean']['output'];
   description?: Maybe<Scalars['String']['output']>;
   key: Scalars['String']['output'];
+  limitSelectionToProject: Scalars['Boolean']['output'];
   name: Scalars['String']['output'];
+  parentShouldBuildWithChild: Scalars['Boolean']['output'];
   relatedTo: Scalars['String']['output'];
   required: Scalars['Boolean']['output'];
 };
@@ -253,7 +255,9 @@ export type BlueprintRelationUpsertInput = {
   allowMultiple: Scalars['Boolean']['input'];
   description?: InputMaybe<Scalars['String']['input']>;
   key: Scalars['String']['input'];
+  limitSelectionToProject: Scalars['Boolean']['input'];
   name: Scalars['String']['input'];
+  parentShouldBuildWithChild: Scalars['Boolean']['input'];
   relatedTo: Scalars['String']['input'];
   required: Scalars['Boolean']['input'];
 };

--- a/packages/amplication-cli/src/models.ts
+++ b/packages/amplication-cli/src/models.ts
@@ -244,7 +244,9 @@ export type BlueprintRelation = {
   allowMultiple: Scalars['Boolean']['output'];
   description?: Maybe<Scalars['String']['output']>;
   key: Scalars['String']['output'];
+  limitSelectionToProject: Scalars['Boolean']['output'];
   name: Scalars['String']['output'];
+  parentShouldBuildWithChild: Scalars['Boolean']['output'];
   relatedTo: Scalars['String']['output'];
   required: Scalars['Boolean']['output'];
 };
@@ -253,7 +255,9 @@ export type BlueprintRelationUpsertInput = {
   allowMultiple: Scalars['Boolean']['input'];
   description?: InputMaybe<Scalars['String']['input']>;
   key: Scalars['String']['input'];
+  limitSelectionToProject: Scalars['Boolean']['input'];
   name: Scalars['String']['input'];
+  parentShouldBuildWithChild: Scalars['Boolean']['input'];
   relatedTo: Scalars['String']['input'];
   required: Scalars['Boolean']['input'];
 };

--- a/packages/amplication-client/src/Blueprints/BlueprintRelationAddButton.tsx
+++ b/packages/amplication-client/src/Blueprints/BlueprintRelationAddButton.tsx
@@ -22,6 +22,8 @@ const DEFAULT_RELATION_VALUES: models.BlueprintRelation = {
   key: "",
   relatedTo: "",
   required: false,
+  limitSelectionToProject: false,
+  parentShouldBuildWithChild: false,
 };
 
 const BlueprintRelationAddButton = ({

--- a/packages/amplication-client/src/Blueprints/BlueprintRelationForm.tsx
+++ b/packages/amplication-client/src/Blueprints/BlueprintRelationForm.tsx
@@ -82,12 +82,12 @@ const BlueprintRelationForm = ({
                 label="Limit selection to the same project"
               />
             </div>
-            {/* <div>
+            <div>
               <ToggleField
                 name="parentShouldBuildWithChild"
                 label="Regenerate parent code when building the child"
               />
-            </div> */}
+            </div>
             <div>
               <FlexItem
                 end={

--- a/packages/amplication-client/src/Blueprints/BlueprintRelationForm.tsx
+++ b/packages/amplication-client/src/Blueprints/BlueprintRelationForm.tsx
@@ -77,6 +77,18 @@ const BlueprintRelationForm = ({
               <ToggleField name="required" label="Required" />
             </div>
             <div>
+              <ToggleField
+                name="limitSelectionToProject"
+                label="Limit selection to the same project"
+              />
+            </div>
+            {/* <div>
+              <ToggleField
+                name="parentShouldBuildWithChild"
+                label="Regenerate parent code when building the child"
+              />
+            </div> */}
+            <div>
               <FlexItem
                 end={
                   <Button

--- a/packages/amplication-client/src/Blueprints/ResourceSelectField.tsx
+++ b/packages/amplication-client/src/Blueprints/ResourceSelectField.tsx
@@ -1,8 +1,6 @@
 import { SelectField, SelectFieldProps } from "@amplication/ui/design-system";
-import { useEffect, useMemo } from "react";
+import { useMemo } from "react";
 import useCatalog from "../Catalog/hooks/useCatalog";
-import { EnumResourceType } from "../models";
-import { useAppContext } from "../context/appContext";
 
 type Props = Omit<SelectFieldProps, "options"> & {
   blueprintId?: string;
@@ -11,13 +9,13 @@ type Props = Omit<SelectFieldProps, "options"> & {
 const ResourceSelectField = (props: Props) => {
   const { blueprintId, ...rest } = props;
 
-  const { catalog, setFilter } = useCatalog({ initialPageSize: 200 });
-
-  useEffect(() => {
-    setFilter({
+  const { catalog } = useCatalog({
+    initialPageSize: 200,
+    fetchPolicy: "cache-and-network",
+    initialFilters: {
       blueprintId: [blueprintId],
-    });
-  }, [blueprintId, setFilter]);
+    },
+  });
 
   const options = useMemo(() => {
     return catalog?.map((catalog) => ({

--- a/packages/amplication-client/src/Blueprints/ResourceSelectField.tsx
+++ b/packages/amplication-client/src/Blueprints/ResourceSelectField.tsx
@@ -4,16 +4,18 @@ import useCatalog from "../Catalog/hooks/useCatalog";
 
 type Props = Omit<SelectFieldProps, "options"> & {
   blueprintId?: string;
+  projectId?: string;
 };
 
 const ResourceSelectField = (props: Props) => {
-  const { blueprintId, ...rest } = props;
+  const { blueprintId, projectId, ...rest } = props;
 
   const { catalog } = useCatalog({
     initialPageSize: 200,
     fetchPolicy: "cache-and-network",
     initialFilters: {
       blueprintId: [blueprintId],
+      projectId: projectId ? projectId : undefined,
     },
   });
 

--- a/packages/amplication-client/src/Blueprints/ResourceSelectField.tsx
+++ b/packages/amplication-client/src/Blueprints/ResourceSelectField.tsx
@@ -11,28 +11,13 @@ type Props = Omit<SelectFieldProps, "options"> & {
 const ResourceSelectField = (props: Props) => {
   const { blueprintId, ...rest } = props;
 
-  const {
-    blueprintsMap: { blueprintsMapById },
-  } = useAppContext();
-
   const { catalog, setFilter } = useCatalog({ initialPageSize: 200 });
 
   useEffect(() => {
-    const blueprint = Object.values(blueprintsMapById).find(
-      (blueprint) => blueprint.id === blueprintId
-    );
-
-    if (blueprint?.key === "LEGACY_SERVICE") {
-      //LEGACY_SERVICE is a unique key for services that were created before the introduction of blueprints
-      setFilter({
-        resourceType: EnumResourceType.Service,
-      });
-    } else {
-      setFilter({
-        blueprintId: [blueprintId],
-      });
-    }
-  }, [blueprintId, blueprintsMapById, setFilter]);
+    setFilter({
+      blueprintId: [blueprintId],
+    });
+  }, [blueprintId, setFilter]);
 
   const options = useMemo(() => {
     return catalog?.map((catalog) => ({

--- a/packages/amplication-client/src/Blueprints/queries/blueprintsQueries.ts
+++ b/packages/amplication-client/src/Blueprints/queries/blueprintsQueries.ts
@@ -9,6 +9,8 @@ export const BLUEPRINT_RELATION_FIELDS_FRAGMENT = gql`
     relatedTo
     allowMultiple
     required
+    limitSelectionToProject
+    parentShouldBuildWithChild
   }
 `;
 

--- a/packages/amplication-client/src/Catalog/CatalogContext.tsx
+++ b/packages/amplication-client/src/Catalog/CatalogContext.tsx
@@ -13,6 +13,7 @@ export interface CatalogContextInterface {
   pagination: Pagination;
   sorting: Sorting<models.ResourceOrderByInput[]>;
   reloadCatalog: () => void;
+  searchPhrase: string;
 }
 
 const initialContext: CatalogContextInterface = {
@@ -35,6 +36,7 @@ const initialContext: CatalogContextInterface = {
     setOrderBy: () => {},
   },
   reloadCatalog: () => {},
+  searchPhrase: "",
 };
 
 export const CatalogContext =
@@ -52,6 +54,7 @@ export const CatalogContextProvider: React.FC<{
     pagination,
     sorting,
     reloadCatalog,
+    searchPhrase,
   } = useCatalog();
 
   const contextValue: CatalogContextInterface = {
@@ -63,6 +66,7 @@ export const CatalogContextProvider: React.FC<{
     pagination,
     sorting,
     reloadCatalog,
+    searchPhrase,
   };
 
   return (

--- a/packages/amplication-client/src/Catalog/CatalogGrid.tsx
+++ b/packages/amplication-client/src/Catalog/CatalogGrid.tsx
@@ -56,8 +56,15 @@ function CatalogGrid({ HeaderActions, fixedFilters, fixedFiltersKey }: Props) {
     columnsWithAllProps,
     `${COLUMNS_LOCAL_STORAGE_KEY}-${currentWorkspace?.id}`
   );
-  const { catalog, loading, error, setFilter, setSearchPhrase, pagination } =
-    useCatalogContext();
+  const {
+    catalog,
+    loading,
+    error,
+    setFilter,
+    setSearchPhrase,
+    pagination,
+    searchPhrase,
+  } = useCatalogContext();
 
   const errorMessage = formatError(error);
 
@@ -90,6 +97,7 @@ function CatalogGrid({ HeaderActions, fixedFilters, fixedFiltersKey }: Props) {
                   label="search"
                   placeholder="search"
                   onChange={setSearchPhrase}
+                  value={searchPhrase}
                 />
                 <DataGridColumnFilter
                   columns={columns}

--- a/packages/amplication-client/src/Catalog/hooks/useCatalog.ts
+++ b/packages/amplication-client/src/Catalog/hooks/useCatalog.ts
@@ -20,10 +20,16 @@ const DEFAULT_PROJECT_TYPE_FILTER: models.EnumResourceTypeFilter = {
 
 type Props = {
   initialPageSize?: number;
+  initialFilters?: Record<string, string | string[]>;
+  fetchPolicy?: "cache-and-network" | "cache-first";
 };
 
 const useCatalog = (props?: Props) => {
-  const { initialPageSize } = props || {};
+  const {
+    initialPageSize,
+    initialFilters,
+    fetchPolicy = "cache-first",
+  } = props || {};
 
   const { customPropertiesMap } = useAppContext();
 
@@ -48,12 +54,16 @@ const useCatalog = (props?: Props) => {
     resourceType: DEFAULT_PROJECT_TYPE_FILTER,
   });
 
+  const [skipQuery, setSkipQuery] = useState(!!initialFilters);
+
   const {
     data: catalogData,
     loading,
     error,
     refetch,
   } = useQuery<CatalogResults>(SEARCH_CATALOG, {
+    fetchPolicy,
+    skip: skipQuery,
     variables: {
       ...queryPaginationParams,
       where: {
@@ -162,6 +172,13 @@ const useCatalog = (props?: Props) => {
     pagination.setPageNumber(1);
     refetch();
   }, [pagination, refetch]);
+
+  useEffect(() => {
+    if (initialFilters) {
+      setFilter(initialFilters);
+      setSkipQuery(false);
+    }
+  }, []);
 
   return {
     catalog: currentPageData || [],

--- a/packages/amplication-client/src/Catalog/hooks/useCatalog.ts
+++ b/packages/amplication-client/src/Catalog/hooks/useCatalog.ts
@@ -167,6 +167,7 @@ const useCatalog = (props?: Props) => {
     catalog: currentPageData || [],
     loading,
     error,
+    searchPhrase,
     setSearchPhrase,
     setFilter,
     pagination,

--- a/packages/amplication-client/src/Relation/ResourceRelationForm.tsx
+++ b/packages/amplication-client/src/Relation/ResourceRelationForm.tsx
@@ -1,20 +1,12 @@
-import {
-  EnumItemsAlign,
-  EnumPanelStyle,
-  FlexItem,
-  Panel,
-  Snackbar,
-  TabContentTitle,
-} from "@amplication/ui/design-system";
+import { Snackbar } from "@amplication/ui/design-system";
 import { Form, Formik } from "formik";
 import { useCallback } from "react";
-import BlueprintCircleBadge from "../Blueprints/BlueprintCircleBadge";
 import ResourceSelectField from "../Blueprints/ResourceSelectField";
+import { useAppContext } from "../context/appContext";
 import * as models from "../models";
 import { formatError } from "../util/error";
-import useResourceRelations from "./hooks/useResourceRelations";
 import FormikAutoSave from "../util/formikAutoSave";
-import { useAppContext } from "../context/appContext";
+import useResourceRelations from "./hooks/useResourceRelations";
 
 type Props = {
   resourceId: string;
@@ -35,6 +27,7 @@ function ResourceRelationsForm({ resourceId, relationDef, relation }: Props) {
 
   const {
     blueprintsMap: { blueprintsMap },
+    currentProject,
   } = useAppContext();
 
   const errorMessage = formatError(updateRelationError);
@@ -71,23 +64,28 @@ function ResourceRelationsForm({ resourceId, relationDef, relation }: Props) {
   const relatedBlueprint = blueprintsMap[relationDef.relatedTo];
 
   return (
-    <div className={CLASS_NAME}>
+    <div className={CLASS_NAME} key={resourceId}>
       <Formik
         initialValues={initialValue}
         enableReinitialize
         onSubmit={handleSubmit}
       >
-        {() => {
+        {(formik) => {
           return (
             <>
               <Form>
                 <FormikAutoSave debounceMS={100} />
-
+                {formik.values.relatedResources}
                 <ResourceSelectField
                   label={relationDef.name}
                   isMulti={relationDef.allowMultiple}
                   name={"relatedResources"}
                   blueprintId={relatedBlueprint?.id}
+                  projectId={
+                    relationDef.limitSelectionToProject
+                      ? currentProject?.id
+                      : undefined
+                  }
                 />
               </Form>
               <Snackbar

--- a/packages/amplication-client/src/Relation/ResourceRelationForm.tsx
+++ b/packages/amplication-client/src/Relation/ResourceRelationForm.tsx
@@ -75,7 +75,6 @@ function ResourceRelationsForm({ resourceId, relationDef, relation }: Props) {
             <>
               <Form>
                 <FormikAutoSave debounceMS={100} />
-                {formik.values.relatedResources}
                 <ResourceSelectField
                   label={relationDef.name}
                   isMulti={relationDef.allowMultiple}

--- a/packages/amplication-client/src/Relation/ResourceRelations.tsx
+++ b/packages/amplication-client/src/Relation/ResourceRelations.tsx
@@ -39,8 +39,6 @@ function ResourceRelations() {
           <>
             <TabContentTitle title="Related Resources" />
             <Panel panelStyle={EnumPanelStyle.Bordered}>
-              <div>{JSON.stringify(relationsMap)}</div>
-
               {currentBlueprint?.relations?.map((relationDef) => (
                 <ResourceRelationsForm
                   key={relationDef.key}

--- a/packages/amplication-client/src/Relation/ResourceRelations.tsx
+++ b/packages/amplication-client/src/Relation/ResourceRelations.tsx
@@ -39,6 +39,8 @@ function ResourceRelations() {
           <>
             <TabContentTitle title="Related Resources" />
             <Panel panelStyle={EnumPanelStyle.Bordered}>
+              <div>{JSON.stringify(relationsMap)}</div>
+
               {currentBlueprint?.relations?.map((relationDef) => (
                 <ResourceRelationsForm
                   key={relationDef.key}

--- a/packages/amplication-client/src/Relation/hooks/useResourceRelations.tsx
+++ b/packages/amplication-client/src/Relation/hooks/useResourceRelations.tsx
@@ -28,6 +28,12 @@ const useResourceRelations = (resourceId?: string) => {
     onCompleted: (data) => {
       addEntity(data.updateResourceRelation.id);
     },
+    refetchQueries: [
+      {
+        query: GET_RESOURCE_RELATIONS,
+        variables: { resourceId: resourceId },
+      },
+    ],
   });
 
   return {

--- a/packages/amplication-client/src/models.ts
+++ b/packages/amplication-client/src/models.ts
@@ -247,7 +247,9 @@ export type BlueprintRelation = {
   allowMultiple: Scalars['Boolean']['output'];
   description?: Maybe<Scalars['String']['output']>;
   key: Scalars['String']['output'];
+  limitSelectionToProject: Scalars['Boolean']['output'];
   name: Scalars['String']['output'];
+  parentShouldBuildWithChild: Scalars['Boolean']['output'];
   relatedTo: Scalars['String']['output'];
   required: Scalars['Boolean']['output'];
 };
@@ -256,7 +258,9 @@ export type BlueprintRelationUpsertInput = {
   allowMultiple: Scalars['Boolean']['input'];
   description?: InputMaybe<Scalars['String']['input']>;
   key: Scalars['String']['input'];
+  limitSelectionToProject: Scalars['Boolean']['input'];
   name: Scalars['String']['input'];
+  parentShouldBuildWithChild: Scalars['Boolean']['input'];
   relatedTo: Scalars['String']['input'];
   required: Scalars['Boolean']['input'];
 };

--- a/packages/amplication-prisma-db/prisma/migrations/20250311123220_migration/migration.sql
+++ b/packages/amplication-prisma-db/prisma/migrations/20250311123220_migration/migration.sql
@@ -1,0 +1,16 @@
+-- CreateTable
+CREATE TABLE "ResourceRelationCache" (
+    "id" TEXT NOT NULL,
+    "parentResourceId" TEXT NOT NULL,
+    "relationKey" TEXT NOT NULL,
+    "childResourceId" TEXT NOT NULL,
+    "parentShouldBuildWithChild" BOOLEAN NOT NULL DEFAULT false,
+
+    CONSTRAINT "ResourceRelationCache_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "ResourceRelationCache" ADD CONSTRAINT "ResourceRelationCache_parentResourceId_fkey" FOREIGN KEY ("parentResourceId") REFERENCES "Resource"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ResourceRelationCache" ADD CONSTRAINT "ResourceRelationCache_childResourceId_fkey" FOREIGN KEY ("childResourceId") REFERENCES "Resource"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/amplication-prisma-db/prisma/schema.prisma
+++ b/packages/amplication-prisma-db/prisma/schema.prisma
@@ -251,8 +251,24 @@ model Resource {
   blueprint             Blueprint?                   @relation(fields: [blueprintId], references: [id], onDelete: NoAction, onUpdate: Cascade)
   teamAssignments       TeamAssignment[]
 
+  parentResourceRelations ResourceRelationCache[] @relation("ParentResource")
+  childResourceRelations  ResourceRelationCache[] @relation("ChildResource")
+
   @@unique([projectId, name], map: "Resource.projectId_name_unique")
   @@index([properties(ops: JsonbOps)], type: Gin)
+}
+
+//this is a calculated table that is used to store the relations between resources 
+//it is used to allow performant queries on the relations
+model ResourceRelationCache {
+  id               String   @id @default(cuid())
+  parentResourceId String
+  parentResource   Resource @relation("ParentResource", fields: [parentResourceId], references: [id], onDelete: Cascade)
+  relationKey      String
+  childResourceId  String
+  childResource    Resource @relation("ChildResource", fields: [childResourceId], references: [id], onDelete: Cascade)
+
+  parentShouldBuildWithChild Boolean @default(false)
 }
 
 model ResourceRole {

--- a/packages/amplication-server/src/core/blueprint/blueprint.module.ts
+++ b/packages/amplication-server/src/core/blueprint/blueprint.module.ts
@@ -1,12 +1,17 @@
-import { Module } from "@nestjs/common";
+import { Module, forwardRef } from "@nestjs/common";
 import { PrismaModule } from "../../prisma/prisma.module";
 import { PermissionsModule } from "../permissions/permissions.module";
 import { BlueprintResolver } from "./blueprint.resolver";
 import { BlueprintService } from "./blueprint.service";
 import { CustomPropertyModule } from "../customProperty/customProperty.module";
-
+import { RelationModule } from "../relation/relation.module";
 @Module({
-  imports: [PrismaModule, PermissionsModule, CustomPropertyModule],
+  imports: [
+    PrismaModule,
+    PermissionsModule,
+    CustomPropertyModule,
+    forwardRef(() => RelationModule),
+  ],
   providers: [BlueprintResolver, BlueprintService],
   exports: [BlueprintResolver, BlueprintService],
 })

--- a/packages/amplication-server/src/core/blueprint/blueprint.service.spec.ts
+++ b/packages/amplication-server/src/core/blueprint/blueprint.service.spec.ts
@@ -7,6 +7,7 @@ import { BlueprintService } from "./blueprint.service";
 import { CustomPropertyService } from "../customProperty/customProperty.service";
 import { EnumResourceType } from "../resource/dto/EnumResourceType";
 import { EnumCodeGenerator } from "../resource/dto/EnumCodeGenerator";
+import { RelationService } from "../relation/relation.service";
 
 const EXAMPLE_BLUEPRINT_ID = "exampleBlueprintId";
 const EXAMPLE_BLUEPRINT_KEY = "exampleBlueprintKey";
@@ -97,6 +98,12 @@ describe("BlueprintService", () => {
         {
           provide: CustomPropertyService,
           useValue: {},
+        },
+        {
+          provide: RelationService,
+          useValue: {
+            updateBlueprintResourceRelationCache: jest.fn(),
+          },
         },
 
         MockedSegmentAnalyticsProvider(),

--- a/packages/amplication-server/src/core/blueprint/blueprint.service.ts
+++ b/packages/amplication-server/src/core/blueprint/blueprint.service.ts
@@ -232,7 +232,13 @@ export class BlueprintService {
           )
         : null,
       relations: record.relations
-        ? (record.relations as unknown as BlueprintRelation[])
+        ? (record.relations as unknown as BlueprintRelation[]).map(
+            (relation) => ({
+              limitSelectionToProject: false, //use default value for backward compatibility
+              parentShouldBuildWithChild: false, //use default value for backward compatibility
+              ...relation,
+            })
+          )
         : null,
     };
   }

--- a/packages/amplication-server/src/core/blueprint/dto/BlueprintRelationUpsertInput.ts
+++ b/packages/amplication-server/src/core/blueprint/dto/BlueprintRelationUpsertInput.ts
@@ -33,4 +33,14 @@ export class BlueprintRelationUpsertInput {
     nullable: false,
   })
   required!: boolean;
+
+  @Field(() => Boolean, {
+    nullable: false,
+  })
+  limitSelectionToProject!: boolean;
+
+  @Field(() => Boolean, {
+    nullable: false,
+  })
+  parentShouldBuildWithChild!: boolean;
 }

--- a/packages/amplication-server/src/core/build/build.service.spec.ts
+++ b/packages/amplication-server/src/core/build/build.service.spec.ts
@@ -248,6 +248,10 @@ const privatePluginServiceAvailablePrivatePluginsForResourceMock = jest.fn(
   () => [EXAMPLE_PRIVATE_PLUGIN, EXAMPLE_PRIVATE_PLUGIN_2]
 );
 
+const resourceServiceGetRelatedResourcesRecursiveMock = jest.fn(() => [
+  EXAMPLE_RESOURCE,
+]);
+
 describe("BuildService", () => {
   let service: BuildService;
 
@@ -377,6 +381,8 @@ describe("BuildService", () => {
             resource: resourceServiceFindOneMock,
             resources: resourceServiceFindManyMock,
             getRelations: jest.fn(() => []),
+            getRelatedResourcesRecursive:
+              resourceServiceGetRelatedResourcesRecursiveMock,
             getPluginRepositoryGitSettingsByResource:
               resourceServiceGetPluginRepositoryGitSettingsByResourceMock,
           })),

--- a/packages/amplication-server/src/core/build/build.service.ts
+++ b/packages/amplication-server/src/core/build/build.service.ts
@@ -1432,6 +1432,9 @@ export class BuildService {
         ];
       }
 
+      this.logger.info(
+        `attaching related resources data for resource ${resourceId} with ${resources.length} related resources`
+      );
       otherResources = await Promise.all(
         resources
           .filter(({ id }) => id !== resourceId)

--- a/packages/amplication-server/src/core/build/build.service.ts
+++ b/packages/amplication-server/src/core/build/build.service.ts
@@ -1400,10 +1400,14 @@ export class BuildService {
 
     if (rootGeneration) {
       let resources = [];
-      if (resource.resourceType === EnumResourceType.Component) {
-        resources = await this.resourceService.getRelatedResource(resourceId); // get all resources
-      } else {
-        resources = await this.resourceService.resources({
+
+      resources = await this.resourceService.getRelatedResourcesRecursive(
+        resourceId
+      ); // get all related resources
+
+      //for backward compatibility, we need to add the project resources to the list of related resources
+      if (resource.resourceType === EnumResourceType.Service) {
+        const projectResources = await this.resourceService.resources({
           where: {
             project: { id: resource.projectId },
             resourceType: {
@@ -1416,6 +1420,16 @@ export class BuildService {
             },
           },
         });
+
+        resources = [
+          ...resources,
+          ...projectResources.filter(
+            (projectResource) =>
+              !resources.some(
+                (relatedResource) => relatedResource.id === projectResource.id
+              )
+          ),
+        ];
       }
 
       otherResources = await Promise.all(

--- a/packages/amplication-server/src/core/project/project.module.ts
+++ b/packages/amplication-server/src/core/project/project.module.ts
@@ -11,7 +11,7 @@ import { ProjectService } from "./project.service";
 import { GitProviderModule } from "../git/git.provider.module";
 import { SubscriptionModule } from "../subscription/subscription.module";
 import { ResourceVersionModule } from "../resourceVersion/resourceVersion.module";
-
+import { RelationModule } from "../relation/relation.module";
 @Module({
   imports: [
     PrismaModule,
@@ -24,6 +24,7 @@ import { ResourceVersionModule } from "../resourceVersion/resourceVersion.module
     GitProviderModule,
     SubscriptionModule,
     ResourceVersionModule,
+    RelationModule,
   ],
   providers: [ProjectResolver, ProjectService],
   exports: [ProjectResolver, ProjectService],

--- a/packages/amplication-server/src/core/project/project.service.spec.ts
+++ b/packages/amplication-server/src/core/project/project.service.spec.ts
@@ -42,6 +42,7 @@ import { RESOURCE_TYPE_GROUP_TO_RESOURCE_TYPE } from "../resource/constants";
 import { ResourceVersionService } from "../resourceVersion/resourceVersion.service";
 import { EnumBuildStatus } from "../build/dto/EnumBuildStatus";
 import { EnumBuildGitStatus } from "../build/dto/EnumBuildGitStatus";
+import { RelationService } from "../relation/relation.service";
 
 /** values mock */
 const EXAMPLE_USER_ID = "exampleUserId";
@@ -304,6 +305,9 @@ const createProjectConfigurationMock = jest.fn(() => {
 const blockServiceReleaseLockMock = jest.fn(async () => EXAMPLE_BLOCK);
 const mockedUpdateProjectLicensed = jest.fn();
 const mockedUpdateServiceLicensed = jest.fn();
+const relationServiceGetCascadingBuildableResourceIdsMock = jest.fn(
+  (resourceIds: string[]) => Promise.resolve(resourceIds)
+);
 
 describe("ProjectService", () => {
   let service: ProjectService;
@@ -382,6 +386,13 @@ describe("ProjectService", () => {
           useClass: jest.fn(() => ({
             createProjectConfiguration: createProjectConfigurationMock,
             archiveProjectResources: jest.fn(() => Promise.resolve([])),
+          })),
+        },
+        {
+          provide: RelationService,
+          useClass: jest.fn(() => ({
+            getCascadingBuildableResourceIds:
+              relationServiceGetCascadingBuildableResourceIdsMock,
           })),
         },
         {

--- a/packages/amplication-server/src/core/relation/relation.module.ts
+++ b/packages/amplication-server/src/core/relation/relation.module.ts
@@ -1,11 +1,19 @@
-import { Module } from "@nestjs/common";
+import { Module, forwardRef } from "@nestjs/common";
 import { RelationService } from "./relation.service";
 import { RelationResolver } from "./relation.resolver";
 import { BlockModule } from "../block/block.module";
 import { PermissionsModule } from "../permissions/permissions.module";
 import { UserModule } from "../user/user.module";
+import { BlueprintModule } from "../blueprint/blueprint.module";
+import { PrismaModule } from "../../prisma";
 @Module({
-  imports: [UserModule, BlockModule, PermissionsModule],
+  imports: [
+    UserModule,
+    BlockModule,
+    PermissionsModule,
+    PrismaModule,
+    forwardRef(() => BlueprintModule),
+  ],
   providers: [RelationService, RelationResolver],
   exports: [RelationService, RelationResolver],
 })

--- a/packages/amplication-server/src/core/relation/relation.service.spec.ts
+++ b/packages/amplication-server/src/core/relation/relation.service.spec.ts
@@ -1,0 +1,446 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { MockedAmplicationLoggerProvider } from "@amplication/util/nestjs/logging/test-utils";
+import { EnumBlockType } from "../../enums/EnumBlockType";
+import { User, Resource, Blueprint } from "../../models";
+import { PrismaService } from "../../prisma";
+import { BlockService } from "../block/block.service";
+import { BlueprintService } from "../blueprint/blueprint.service";
+import { RelationService } from "./relation.service";
+import { Relation } from "./dto/Relation";
+import { UpdateResourceRelationArgs } from "./dto/UpdateResourceRelationArgs";
+
+// Test constants
+const EXAMPLE_USER_ID = "exampleUserId";
+const EXAMPLE_RESOURCE_ID = "exampleResourceId";
+const EXAMPLE_BLUEPRINT_ID = "exampleBlueprintId";
+const EXAMPLE_WORKSPACE_ID = "exampleWorkspaceId";
+const EXAMPLE_RELATION_ID = "exampleRelationId";
+const EXAMPLE_RELATION_KEY = "exampleRelationKey";
+const EXAMPLE_RELATED_RESOURCE_ID = "exampleRelatedResourceId";
+
+const EXAMPLE_USER: User = {
+  id: EXAMPLE_USER_ID,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  workspace: {
+    id: EXAMPLE_WORKSPACE_ID,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    name: "example_workspace_name",
+    allowLLMFeatures: true,
+  },
+  isOwner: true,
+};
+
+const EXAMPLE_RESOURCE: Resource = {
+  id: EXAMPLE_RESOURCE_ID,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  name: "exampleResourceName",
+  description: "exampleResourceDescription",
+  resourceType: "Service",
+  blueprintId: EXAMPLE_BLUEPRINT_ID,
+  gitRepositoryOverride: false,
+  licensed: true,
+};
+
+const EXAMPLE_BLUEPRINT: Blueprint = {
+  id: EXAMPLE_BLUEPRINT_ID,
+  name: "exampleBlueprintName",
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  workspaceId: EXAMPLE_WORKSPACE_ID,
+  properties: null,
+  key: "exampleBlueprintKey",
+  enabled: true,
+  relations: [
+    {
+      key: EXAMPLE_RELATION_KEY,
+      parentShouldBuildWithChild: true,
+      name: "Example Relation",
+      relatedTo: "ExampleRelatedTo",
+      allowMultiple: true,
+      required: false,
+      limitSelectionToProject: false,
+    },
+  ],
+  codeGeneratorName: "Blueprint",
+  resourceType: "Component",
+  useBusinessDomain: false,
+};
+
+const EXAMPLE_RELATION: Relation = {
+  id: EXAMPLE_RELATION_ID,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  resourceId: EXAMPLE_RESOURCE_ID,
+  displayName: EXAMPLE_RELATION_KEY,
+  blockType: EnumBlockType.Relation,
+  relationKey: EXAMPLE_RELATION_KEY,
+  relatedResources: [EXAMPLE_RELATED_RESOURCE_ID],
+  versionNumber: 0,
+  parentBlock: null,
+  lockedByUserId: null,
+  lockedAt: null,
+  description: "Example relation description",
+  inputParameters: null,
+  outputParameters: null,
+};
+
+// Mock implementations
+const prismaResourceFindUniqueMock = jest.fn(() => EXAMPLE_RESOURCE);
+const prismaResourceFindManyMock = jest.fn(() => [EXAMPLE_RESOURCE]);
+const prismaResourceRelationCacheDeleteManyMock = jest.fn();
+const prismaResourceRelationCacheCreateManyMock = jest.fn();
+const prismaResourceRelationCacheFindManyMock = jest.fn(() => [
+  {
+    parentResourceId: "parentResourceId",
+    childResourceId: EXAMPLE_RESOURCE_ID,
+    relationKey: EXAMPLE_RELATION_KEY,
+    parentShouldBuildWithChild: true,
+  },
+]);
+
+const prismaMock = {
+  resource: {
+    findUnique: prismaResourceFindUniqueMock,
+    findMany: prismaResourceFindManyMock,
+  },
+  resourceRelationCache: {
+    deleteMany: prismaResourceRelationCacheDeleteManyMock,
+    createMany: prismaResourceRelationCacheCreateManyMock,
+    findMany: prismaResourceRelationCacheFindManyMock,
+  },
+};
+
+const blockServiceFindManyByBlockTypeAndSettingsMock = jest.fn(() => [
+  EXAMPLE_RELATION,
+]);
+const blockServiceCreateMock = jest.fn(() => EXAMPLE_RELATION);
+const blockServiceUpdateMock = jest.fn(() => EXAMPLE_RELATION);
+const blockServiceFindManyByBlockTypeMock = jest.fn(() => [EXAMPLE_RELATION]);
+
+const blockServiceMock = {
+  findManyByBlockTypeAndSettings:
+    blockServiceFindManyByBlockTypeAndSettingsMock,
+  findManyByBlockType: blockServiceFindManyByBlockTypeMock,
+  create: blockServiceCreateMock,
+  update: blockServiceUpdateMock,
+};
+
+const blueprintServiceBlueprintMock = jest.fn(() => EXAMPLE_BLUEPRINT);
+
+const blueprintServiceMock = {
+  blueprint: blueprintServiceBlueprintMock,
+};
+
+describe("RelationService", () => {
+  let service: RelationService;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        RelationService,
+        {
+          provide: BlockService,
+          useValue: blockServiceMock,
+        },
+        MockedAmplicationLoggerProvider,
+        {
+          provide: PrismaService,
+          useValue: prismaMock,
+        },
+        {
+          provide: BlueprintService,
+          useValue: blueprintServiceMock,
+        },
+      ],
+    }).compile();
+
+    service = module.get<RelationService>(RelationService);
+  });
+
+  it("should be defined", () => {
+    expect(service).toBeDefined();
+  });
+
+  describe("create", () => {
+    it("should throw an error", async () => {
+      await expect(
+        service.create({ data: {} } as any, EXAMPLE_USER)
+      ).rejects.toThrow(
+        "Method not implemented. use updateResourceRelation instead"
+      );
+    });
+  });
+
+  describe("update", () => {
+    it("should throw an error", async () => {
+      await expect(
+        service.update({ where: { id: "id" }, data: {} } as any, EXAMPLE_USER)
+      ).rejects.toThrow(
+        "Method not implemented. use updateResourceRelation instead"
+      );
+    });
+  });
+
+  describe("updateResourceRelation", () => {
+    it("should create a new relation if it doesn't exist", async () => {
+      // Arrange
+      blockServiceFindManyByBlockTypeAndSettingsMock.mockReturnValueOnce([]);
+
+      const args: UpdateResourceRelationArgs = {
+        resource: { id: EXAMPLE_RESOURCE_ID },
+        data: {
+          relationKey: EXAMPLE_RELATION_KEY,
+          relatedResources: [EXAMPLE_RELATED_RESOURCE_ID],
+        },
+      };
+
+      // Mock the updateResourceRelationCache method
+      jest
+        .spyOn(service, "updateResourceRelationCache")
+        .mockResolvedValueOnce();
+
+      // Act
+      const result = await service.updateResourceRelation(args, EXAMPLE_USER);
+
+      // Assert
+      expect(result).toEqual(EXAMPLE_RELATION);
+      expect(
+        blockServiceFindManyByBlockTypeAndSettingsMock
+      ).toHaveBeenCalledTimes(1);
+      expect(blockServiceCreateMock).toHaveBeenCalledTimes(1);
+      expect(blockServiceCreateMock).toHaveBeenCalledWith(
+        {
+          data: {
+            relationKey: EXAMPLE_RELATION_KEY,
+            relatedResources: [EXAMPLE_RELATED_RESOURCE_ID],
+            displayName: EXAMPLE_RELATION_KEY,
+            resource: {
+              connect: {
+                id: EXAMPLE_RESOURCE_ID,
+              },
+            },
+            blockType: EnumBlockType.Relation,
+          },
+        },
+        EXAMPLE_USER_ID
+      );
+      expect(service.updateResourceRelationCache).toHaveBeenCalledWith(
+        EXAMPLE_RESOURCE_ID
+      );
+    });
+
+    it("should update an existing relation if it exists", async () => {
+      // Arrange
+      const args: UpdateResourceRelationArgs = {
+        resource: { id: EXAMPLE_RESOURCE_ID },
+        data: {
+          relationKey: EXAMPLE_RELATION_KEY,
+          relatedResources: [EXAMPLE_RELATED_RESOURCE_ID],
+        },
+      };
+
+      // Mock the updateResourceRelationCache method
+      jest
+        .spyOn(service, "updateResourceRelationCache")
+        .mockResolvedValueOnce();
+
+      // Act
+      const result = await service.updateResourceRelation(args, EXAMPLE_USER);
+
+      // Assert
+      expect(result).toEqual(EXAMPLE_RELATION);
+      expect(
+        blockServiceFindManyByBlockTypeAndSettingsMock
+      ).toHaveBeenCalledTimes(1);
+      expect(blockServiceUpdateMock).toHaveBeenCalledTimes(1);
+      expect(blockServiceUpdateMock).toHaveBeenCalledWith(
+        {
+          where: { id: EXAMPLE_RELATION_ID },
+          data: {
+            relationKey: EXAMPLE_RELATION_KEY,
+            relatedResources: [EXAMPLE_RELATED_RESOURCE_ID],
+            displayName: EXAMPLE_RELATION_KEY,
+          },
+        },
+        EXAMPLE_USER,
+        undefined
+      );
+      expect(service.updateResourceRelationCache).toHaveBeenCalledWith(
+        EXAMPLE_RESOURCE_ID
+      );
+    });
+  });
+
+  describe("updateWorkspaceResourceRelationCache", () => {
+    it("should update relation cache for all resources in the workspace", async () => {
+      // Arrange
+      jest.spyOn(service, "updateResourceRelationCache").mockResolvedValue();
+
+      // Act
+      await service.updateWorkspaceResourceRelationCache(EXAMPLE_WORKSPACE_ID);
+
+      // Assert
+      expect(prismaResourceFindManyMock).toHaveBeenCalledTimes(1);
+      expect(prismaResourceFindManyMock).toHaveBeenCalledWith({
+        where: {
+          project: {
+            workspaceId: EXAMPLE_WORKSPACE_ID,
+          },
+          deletedAt: null,
+          archived: { not: true },
+        },
+      });
+      expect(service.updateResourceRelationCache).toHaveBeenCalledTimes(1);
+      expect(service.updateResourceRelationCache).toHaveBeenCalledWith(
+        EXAMPLE_RESOURCE_ID
+      );
+    });
+  });
+
+  describe("updateBlueprintResourceRelationCache", () => {
+    it("should update relation cache for all resources in the blueprint", async () => {
+      // Arrange
+      jest.spyOn(service, "updateResourceRelationCache").mockResolvedValue();
+
+      // Act
+      await service.updateBlueprintResourceRelationCache(EXAMPLE_BLUEPRINT_ID);
+
+      // Assert
+      expect(prismaResourceFindManyMock).toHaveBeenCalledTimes(1);
+      expect(prismaResourceFindManyMock).toHaveBeenCalledWith({
+        where: {
+          blueprintId: EXAMPLE_BLUEPRINT_ID,
+          deletedAt: null,
+          archived: { not: true },
+        },
+      });
+      expect(service.updateResourceRelationCache).toHaveBeenCalledTimes(1);
+      expect(service.updateResourceRelationCache).toHaveBeenCalledWith(
+        EXAMPLE_RESOURCE_ID
+      );
+    });
+  });
+
+  describe("updateResourceRelationCache", () => {
+    it("should update the resource relation cache", async () => {
+      // Arrange
+      blockServiceFindManyByBlockTypeMock.mockReturnValueOnce([
+        EXAMPLE_RELATION,
+      ]);
+
+      // Act
+      await service.updateResourceRelationCache(EXAMPLE_RESOURCE_ID);
+
+      // Assert
+      expect(blockServiceFindManyByBlockTypeMock).toHaveBeenCalledTimes(1);
+      expect(prismaResourceFindUniqueMock).toHaveBeenCalledTimes(1);
+      expect(prismaResourceFindUniqueMock).toHaveBeenCalledWith({
+        where: {
+          id: EXAMPLE_RESOURCE_ID,
+        },
+      });
+      expect(blueprintServiceBlueprintMock).toHaveBeenCalledTimes(1);
+      expect(prismaResourceRelationCacheDeleteManyMock).toHaveBeenCalledTimes(
+        2
+      );
+      expect(prismaResourceRelationCacheCreateManyMock).toHaveBeenCalledTimes(
+        1
+      );
+    });
+
+    it("should log error if resource does not exist", async () => {
+      // Arrange
+      prismaResourceFindUniqueMock.mockReturnValueOnce(null);
+      const loggerErrorSpy = jest.spyOn(service["logger"], "error");
+
+      // Act
+      await service.updateResourceRelationCache(EXAMPLE_RESOURCE_ID);
+
+      // Assert
+      expect(loggerErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "Cannot update resource relation cache for resource"
+        )
+      );
+    });
+
+    it("should log error if blueprint does not exist", async () => {
+      // Arrange
+      blueprintServiceBlueprintMock.mockReturnValueOnce(null);
+      const loggerErrorSpy = jest.spyOn(service["logger"], "error");
+
+      // Act
+      await service.updateResourceRelationCache(EXAMPLE_RESOURCE_ID);
+
+      // Assert
+      expect(loggerErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "Cannot update resource relation cache for resource"
+        )
+      );
+    });
+  });
+
+  describe("getCascadingBuildableResourceIds", () => {
+    it("should return cascading buildable resource ids", async () => {
+      // Arrange
+      const resourceIds = [EXAMPLE_RESOURCE_ID];
+      const parentResourceId = "parentResourceId";
+
+      // Mock the findMany to return different results on second call to simulate new resources found
+      prismaResourceRelationCacheFindManyMock
+        .mockReturnValueOnce([
+          {
+            parentResourceId,
+            childResourceId: EXAMPLE_RESOURCE_ID,
+            relationKey: EXAMPLE_RELATION_KEY,
+            parentShouldBuildWithChild: true,
+          },
+        ])
+        .mockReturnValueOnce([]);
+
+      // Act
+      const result = await service.getCascadingBuildableResourceIds(
+        resourceIds
+      );
+
+      // Assert
+      expect(result).toContain(EXAMPLE_RESOURCE_ID);
+      expect(result).toContain(parentResourceId);
+      expect(prismaResourceRelationCacheFindManyMock).toHaveBeenCalledTimes(2);
+      expect(prismaResourceRelationCacheFindManyMock).toHaveBeenCalledWith({
+        where: {
+          parentShouldBuildWithChild: true,
+          childResourceId: { in: resourceIds },
+        },
+      });
+    });
+
+    it("should handle errors during cascading resource id retrieval", async () => {
+      // Arrange
+      const resourceIds = [EXAMPLE_RESOURCE_ID];
+      prismaResourceRelationCacheFindManyMock.mockImplementationOnce(() => {
+        throw new Error("Database error");
+      });
+
+      const loggerErrorSpy = jest.spyOn(service["logger"], "error");
+
+      // Act
+      const result = await service.getCascadingBuildableResourceIds(
+        resourceIds
+      );
+
+      // Assert
+      expect(result).toEqual(resourceIds);
+      expect(loggerErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Failed to get buildable parents"),
+        expect.any(Error)
+      );
+    });
+  });
+});

--- a/packages/amplication-server/src/core/relation/relation.service.ts
+++ b/packages/amplication-server/src/core/relation/relation.service.ts
@@ -1,5 +1,5 @@
 import { AmplicationLogger } from "@amplication/util/nestjs/logging";
-import { Injectable } from "@nestjs/common";
+import { Injectable, forwardRef, Inject } from "@nestjs/common";
 import { EnumBlockType } from "../../enums/EnumBlockType";
 import { BlockService } from "../block/block.service";
 import { BlockTypeService } from "../block/blockType.service";
@@ -9,8 +9,9 @@ import { FindManyRelationArgs } from "./dto/FindManyRelationArgs";
 import { Relation } from "./dto/Relation";
 import { UpdateRelationArgs } from "./dto/UpdateRelationArgs";
 import { UpdateResourceRelationArgs } from "./dto/UpdateResourceRelationArgs";
+import { PrismaService, Prisma } from "../../prisma";
+import { BlueprintService } from "../blueprint/blueprint.service";
 import { User } from "../../models";
-
 @Injectable()
 export class RelationService extends BlockTypeService<
   Relation,
@@ -23,9 +24,24 @@ export class RelationService extends BlockTypeService<
 
   constructor(
     protected readonly blockService: BlockService,
-    protected readonly logger: AmplicationLogger
+    protected readonly logger: AmplicationLogger,
+    private readonly prisma: PrismaService,
+    @Inject(forwardRef(() => BlueprintService))
+    private readonly blueprintService: BlueprintService
   ) {
     super(blockService, logger);
+  }
+
+  async create(args: CreateRelationArgs, user: User): Promise<Relation> {
+    throw new Error(
+      "Method not implemented. use updateResourceRelation instead"
+    );
+  }
+
+  async update(args: UpdateRelationArgs, user: User): Promise<Relation> {
+    throw new Error(
+      "Method not implemented. use updateResourceRelation instead"
+    );
   }
 
   async updateResourceRelation(
@@ -50,6 +66,8 @@ export class RelationService extends BlockTypeService<
       ]
     );
 
+    let results: Relation;
+
     if (!existingRelation || existingRelation.length === 0) {
       const createArgs: CreateRelationArgs = {
         data: {
@@ -63,8 +81,7 @@ export class RelationService extends BlockTypeService<
         },
       };
 
-      const results = await super.create(createArgs, user);
-      return results;
+      results = await super.create(createArgs, user);
     } else {
       const updateArgs: UpdateRelationArgs = {
         where: {
@@ -76,8 +93,121 @@ export class RelationService extends BlockTypeService<
         },
       };
 
-      const results = await super.update(updateArgs, user);
-      return results;
+      results = await super.update(updateArgs, user);
     }
+
+    await this.updateResourceRelationCache(args.resource.id);
+
+    return results;
+  }
+
+  /**
+   * Update the resource relation cache for all resources in the workspace
+   * @param workspaceId - The ID of the workspace to update the resource relation cache for
+   */
+  async updateWorkspaceResourceRelationCache(workspaceId: string) {
+    const resources = await this.prisma.resource.findMany({
+      where: {
+        project: {
+          workspaceId,
+        },
+        deletedAt: null,
+        archived: { not: true },
+      },
+    });
+
+    for (const resource of resources) {
+      await this.updateResourceRelationCache(resource.id);
+    }
+  }
+
+  /**
+   * Update the resource relation cache for all resources in the blueprint
+   * @param blueprintId - The ID of the blueprint to update the resource relation cache for
+   */
+  async updateBlueprintResourceRelationCache(blueprintId: string) {
+    const resources = await this.prisma.resource.findMany({
+      where: {
+        blueprintId,
+        deletedAt: null,
+        archived: { not: true },
+      },
+    });
+
+    for (const resource of resources) {
+      await this.updateResourceRelationCache(resource.id);
+    }
+  }
+
+  async updateResourceRelationCache(resourceId: string) {
+    const relations = await this.findMany({
+      where: {
+        resource: {
+          id: resourceId,
+        },
+      },
+    });
+
+    const resource = await this.prisma.resource.findUnique({
+      where: {
+        id: resourceId,
+      },
+    });
+
+    if (!resource) {
+      this.logger.error(
+        `Cannot update resource relation cache for resource ${resourceId} because it does not exist`
+      );
+      return;
+    }
+
+    const blueprint = await this.blueprintService.blueprint({
+      where: {
+        id: resource.blueprintId,
+      },
+    });
+
+    if (!blueprint) {
+      this.logger.error(
+        `Cannot update resource relation cache for resource ${resourceId} because it does not have a blueprint`
+      );
+      return;
+    }
+
+    const createRecords: Prisma.ResourceRelationCacheCreateManyInput[] = [];
+
+    await this.prisma.resourceRelationCache.deleteMany({
+      where: {
+        parentResourceId: resourceId,
+      },
+    });
+
+    const relationMap = blueprint.relations.reduce((acc, relation) => {
+      acc[relation.key] = relation;
+      return acc;
+    }, {});
+
+    //create all the records for the parent resource
+    for (const relation of relations) {
+      for (const relatedResourceId of relation.relatedResources) {
+        createRecords.push({
+          parentResourceId: resourceId,
+          relationKey: relation.relationKey,
+          childResourceId: relatedResourceId,
+          parentShouldBuildWithChild:
+            relationMap[relation.relationKey].parentShouldBuildWithChild,
+        });
+      }
+    }
+
+    await this.prisma.resourceRelationCache.deleteMany({
+      where: {
+        parentResourceId: resourceId,
+      },
+    });
+
+    await this.prisma.resourceRelationCache.createMany({
+      data: createRecords,
+    });
   }
 }

--- a/packages/amplication-server/src/models/BlueprintRelation.ts
+++ b/packages/amplication-server/src/models/BlueprintRelation.ts
@@ -33,4 +33,14 @@ export class BlueprintRelation {
     nullable: false,
   })
   required: boolean;
+
+  @Field(() => Boolean, {
+    nullable: false,
+  })
+  limitSelectionToProject: boolean;
+
+  @Field(() => Boolean, {
+    nullable: false,
+  })
+  parentShouldBuildWithChild: boolean;
 }

--- a/packages/amplication-server/src/schema.graphql
+++ b/packages/amplication-server/src/schema.graphql
@@ -219,7 +219,9 @@ type BlueprintRelation {
   allowMultiple: Boolean!
   description: String
   key: String!
+  limitSelectionToProject: Boolean!
   name: String!
+  parentShouldBuildWithChild: Boolean!
   relatedTo: String!
   required: Boolean!
 }
@@ -228,7 +230,9 @@ input BlueprintRelationUpsertInput {
   allowMultiple: Boolean!
   description: String
   key: String!
+  limitSelectionToProject: Boolean!
   name: String!
+  parentShouldBuildWithChild: Boolean!
   relatedTo: String!
   required: Boolean!
 }

--- a/packages/data-service-generator/src/models.ts
+++ b/packages/data-service-generator/src/models.ts
@@ -244,7 +244,9 @@ export type BlueprintRelation = {
   allowMultiple: Scalars['Boolean']['output'];
   description?: Maybe<Scalars['String']['output']>;
   key: Scalars['String']['output'];
+  limitSelectionToProject: Scalars['Boolean']['output'];
   name: Scalars['String']['output'];
+  parentShouldBuildWithChild: Scalars['Boolean']['output'];
   relatedTo: Scalars['String']['output'];
   required: Scalars['Boolean']['output'];
 };
@@ -253,7 +255,9 @@ export type BlueprintRelationUpsertInput = {
   allowMultiple: Scalars['Boolean']['input'];
   description?: InputMaybe<Scalars['String']['input']>;
   key: Scalars['String']['input'];
+  limitSelectionToProject: Scalars['Boolean']['input'];
   name: Scalars['String']['input'];
+  parentShouldBuildWithChild: Scalars['Boolean']['input'];
   relatedTo: Scalars['String']['input'];
   required: Scalars['Boolean']['input'];
 };

--- a/packages/generator-blueprints/src/models.ts
+++ b/packages/generator-blueprints/src/models.ts
@@ -244,7 +244,9 @@ export type BlueprintRelation = {
   allowMultiple: Scalars['Boolean']['output'];
   description?: Maybe<Scalars['String']['output']>;
   key: Scalars['String']['output'];
+  limitSelectionToProject: Scalars['Boolean']['output'];
   name: Scalars['String']['output'];
+  parentShouldBuildWithChild: Scalars['Boolean']['output'];
   relatedTo: Scalars['String']['output'];
   required: Scalars['Boolean']['output'];
 };
@@ -253,7 +255,9 @@ export type BlueprintRelationUpsertInput = {
   allowMultiple: Scalars['Boolean']['input'];
   description?: InputMaybe<Scalars['String']['input']>;
   key: Scalars['String']['input'];
+  limitSelectionToProject: Scalars['Boolean']['input'];
   name: Scalars['String']['input'];
+  parentShouldBuildWithChild: Scalars['Boolean']['input'];
   relatedTo: Scalars['String']['input'];
   required: Scalars['Boolean']['input'];
 };


### PR DESCRIPTION
# PR Summary

Add Blueprint Relation Fields and Fix Circular Dependencies

## Overview

This PR adds two new boolean fields to the BlueprintRelation GraphQL type and enhances the useCatalog hook with additional parameters. It also resolves circular dependencies between BlueprintModule and RelationModule.

## Change Types

| Type         | Description                            |
|--------------|----------------------------------------|
| Enhancement  | Added new fields to BlueprintRelation type |
| Enhancement  | Added optional parameters to useCatalog hook |
| Refactor     | Fixed circular dependencies between modules |

---

## Affected Modules

| Module / File          | Change Description                       |
|------------------------|------------------------------------------|
| `packages/git-sync-manager/src/models.ts` | Added limitSelectionToProject and parentShouldBuildWithChild fields |
| `amplication-client/src/Catalog/hooks/useCatalog.ts` | Added initialFilters and fetchPolicy parameters |
| `amplication-client/src/models.ts` | Added new fields to BlueprintRelation and BlueprintRelationUpsertInput types |
| `amplication-server/src/core/blueprint/blueprint.module.ts` | Added forwardRef to handle circular dependency |
| `amplication-server/src/core/blueprint/blueprint.service.ts` | Added imports and decorators for circular dependency resolution |
| `amplication-server/src/core/relation/relation.service.ts` | Refactored variable declaration and added imports for circular dependency resolution |

---

## Notes for Reviewers

* Pay attention to the circular dependency resolution between BlueprintModule and RelationModule
* Verify that the new fields in BlueprintRelation are properly integrated across all affected modules